### PR TITLE
fix sidebar can't collapse

### DIFF
--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -9,7 +9,7 @@
     <!-- Header Navbar: style can be found in header.less -->
     <nav class="navbar navbar-static-top">
         <!-- Sidebar toggle button-->
-        <a class="sidebar-toggle" data-toggle="offcanvas" href="#" role="button">
+        <a class="sidebar-toggle" data-toggle="push-menu" href="#" role="button">
             <span class="sr-only">Toggle navigation</span>
         </a>
 


### PR DESCRIPTION
`push-menu` instead of `offcanvas ` since adminLTE2.4.x